### PR TITLE
Implement Configurable difficulty levels with varying constraints

### DIFF
--- a/src/main/java/com/mastermind/config/GameConfig.java
+++ b/src/main/java/com/mastermind/config/GameConfig.java
@@ -1,0 +1,14 @@
+package com.mastermind.config;
+
+/**
+ * Configuration constants for Mastermind game rules and defaults.
+ * These values define the standard game parameters used when no specific
+ * difficulty is selected.
+ */
+final public class GameConfig {
+    public static final int DEFAULT_ANSWER_SIZE = 4;
+    public static final int DEFAULT_MIN_VALUE = 0;
+    public static final int DEFAULT_MAX_VALUE = 7;
+
+    private GameConfig() {}
+}

--- a/src/main/java/com/mastermind/controller/GameController.java
+++ b/src/main/java/com/mastermind/controller/GameController.java
@@ -1,10 +1,6 @@
 package com.mastermind.controller;
 
-import com.mastermind.models.Feedback;
-import com.mastermind.models.Game;
-import com.mastermind.models.NumCombination;
-import com.mastermind.models.Player;
-import com.mastermind.models.Status;
+import com.mastermind.models.*;
 import com.mastermind.services.GameFactory;
 import com.mastermind.ui.MenuChoice;
 import com.mastermind.ui.UserInterface;
@@ -25,7 +21,11 @@ public class GameController {
         boolean playAgain = true;
         while (playAgain) {
             try {
-                Game game = createNewGame();
+                Game game = switch (Difficulty.fromValue(ui.promptForDifficultyLevel())){
+                    case EASY ->createNewGame(Difficulty.EASY);
+                    case NORMAL -> createNewGame();
+                    case HARD -> createNewGame(Difficulty.HARD);
+                };
                 game.start();
                 gameLoop(game);
                 
@@ -38,8 +38,12 @@ public class GameController {
     }
 
     private Game createNewGame() {
+        return createNewGame(Difficulty.NORMAL);
+    }
+
+    private Game createNewGame(Difficulty difficulty) {
         Player player = new Player(ui.promptForPlayerName());
-        return gameFactory.createGame(player);
+        return gameFactory.createGame(player, difficulty);
     }
 
     private void gameLoop(Game game) {
@@ -65,7 +69,13 @@ public class GameController {
     }
 
     private void handleGuess(Game game) {
-        NumCombination guess = ui.promptForGuess(game.getRemainingAttempts());
+        Difficulty difficulty = game.getDifficulty();
+        NumCombination guess = ui.promptForGuess(
+                game.getRemainingAttempts(),
+                difficulty.getCombinationSize(),
+                0, // min value is always 0
+                difficulty.getMaxRange()
+        );
         Feedback feedback = game.playerGuess(guess);
         ui.displayFeedback(guess, feedback);
         

--- a/src/main/java/com/mastermind/models/Difficulty.java
+++ b/src/main/java/com/mastermind/models/Difficulty.java
@@ -1,0 +1,45 @@
+package com.mastermind.models;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+/**
+ * Represents the difficulty levels available in the Mastermind game.
+ * Each difficulty level defines the size of the secret combination and the range of possible numbers.
+ */
+@RequiredArgsConstructor
+@Getter
+public enum Difficulty {
+    /** Easy mode: 3-digit combination with numbers 0-5 */
+    EASY(1, 3, 5),
+    
+    /** Normal mode: 4-digit combination with numbers 0-7 (classic Mastermind) */
+    NORMAL(2, 4, 7),
+    
+    /** Hard mode: 5-digit combination with numbers 0-9 */
+    HARD(3, 5, 9);
+
+    /** The numeric value used for menu selection */
+    private final int value;
+    
+    /** The number of positions in the secret combination */
+    private final int combinationSize;
+    
+    /** The maximum number that can appear in the combination (0-based, inclusive) */
+    private final int maxRange;
+
+    /**
+     * Converts a numeric value to its corresponding Difficulty enum.
+     * 
+     * @param value the numeric value (1=EASY, 2=NORMAL, 3=HARD)
+     * @return the matching Difficulty enum, or null if no match found
+     */
+    public static Difficulty fromValue(int value) {
+        return Arrays.stream(values())
+                .filter(difficulty -> difficulty.value == value)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/mastermind/models/Game.java
+++ b/src/main/java/com/mastermind/models/Game.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -106,17 +107,16 @@ public class Game {
         return this.maxAttempts - this.guesses.size();
     }
 
-    public String getHint() {
+    public Optional<String> getHint() {
         if (this.hintCount == 0){
-            return "No more hints left";
+            return Optional.empty();
         }
 
-        int size = this.answer.getNumbers().size();
-        Random random = new Random();
         this.hintCount--;
 
-        return this.answer.getNumbers()
-                .get(random.nextInt(size))
-                .toString();
+        int size = this.answer.getNumbers().size();
+        int randomIndex = new Random().nextInt(size);
+
+        return Optional.of(this.answer.getNumbers().get(randomIndex).toString());
     }
 }

--- a/src/main/java/com/mastermind/models/Game.java
+++ b/src/main/java/com/mastermind/models/Game.java
@@ -9,13 +9,19 @@ import java.util.Random;
 
 /**
  * Represents a single game session of Mastermind.
+ * 
+ * <p>This class manages the complete game state including player information,
+ * the secret combination, game progression, and difficulty settings.
  *
  * <ul>
  *   <li>Player information ({@link Player})</li>
  *   <li>The secret number combination to guess ({@link NumCombination})</li>
  *   <li>The history of guesses and their corresponding feedback ({@link Feedback})</li>
  *   <li>The game state ({@link Status}) and the maximum number of allowed attempts</li>
+ *   <li>Difficulty level ({@link Difficulty}) that determines game constraints</li>
  * </ul>
+ * 
+ * <p>Games follow a strict lifecycle: PENDING → IN_PROGRESS → (WON|LOST)
  */
 @Data
 @NoArgsConstructor
@@ -27,8 +33,23 @@ public class Game {
     private List<NumCombination> guesses;
     private List<Feedback> feedbacks;
     private int hintCount;
+    private Difficulty difficulty;
 
+    /**
+     * Creates a new game with the specified player and secret combination.
+     * 
+     * @param player the player participating in this game
+     * @param answer the secret combination to be guessed
+     * @throws IllegalArgumentException if player or answer is null
+     */
     public Game(Player player, NumCombination answer) {
+        if (player == null) {
+            throw new IllegalArgumentException("Player cannot be null");
+        }
+        if (answer == null) {
+            throw new IllegalArgumentException("Answer cannot be null");
+        }
+        
         this.status = Status.PENDING;
         this.player = player;
         this.answer = answer;
@@ -51,7 +72,7 @@ public class Game {
         }
 
         if (this.status != Status.IN_PROGRESS) {
-            throw new IllegalArgumentException();
+            throw new IllegalStateException("Game is not in progress");
         }
 
         this.guesses.add(guess);

--- a/src/main/java/com/mastermind/models/NumCombination.java
+++ b/src/main/java/com/mastermind/models/NumCombination.java
@@ -1,5 +1,6 @@
 package com.mastermind.models;
 
+import com.mastermind.config.GameConfig;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -13,17 +14,13 @@ import java.util.regex.Pattern;
  */
 @Data
 public class NumCombination {
-    public static final int DEFAULT_SIZE = 4;
-    public static final int DEFAULT_MIN = 0;
-    public static final int DEFAULT_MAX = 7;
-
     private final List<Integer> numbers;
     private final int expectedSize;
     private final int minNum;
     private final int maxNum;
 
     public NumCombination(List<Integer> numbers) {
-        this(numbers, DEFAULT_SIZE, DEFAULT_MIN, DEFAULT_MAX);
+        this(numbers, GameConfig.DEFAULT_ANSWER_SIZE, GameConfig.DEFAULT_MIN_VALUE, GameConfig.DEFAULT_MAX_VALUE);
     }
 
     public NumCombination(List<Integer> numbers, int expectedSize, int minNum, int maxNum) {
@@ -48,6 +45,20 @@ public class NumCombination {
     }
 
     public static NumCombination parse(String input) {
+        return parse(input, GameConfig.DEFAULT_ANSWER_SIZE, GameConfig.DEFAULT_MIN_VALUE, GameConfig.DEFAULT_MAX_VALUE);
+    }
+
+    /**
+     * Parses a string input into a NumCombination with specified constraints.
+     * 
+     * @param input the string to parse (e.g., "1 2 3 4")
+     * @param expectedSize the required number of digits
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new NumCombination instance
+     * @throws IllegalArgumentException if input is invalid or doesn't meet constraints
+     */
+    public static NumCombination parse(String input, int expectedSize, int min, int max) {
         if (input == null) {
             throw new IllegalArgumentException("Input is null");
         }
@@ -56,7 +67,6 @@ public class NumCombination {
         if (cleanedInput.isBlank()) {
             throw new IllegalArgumentException("Cleaned input is blank");
         }
-
 
         String[] cleanedStrings = cleanedInput.split(Pattern.quote(" "));
 
@@ -72,7 +82,7 @@ public class NumCombination {
             }
         }
 
-        return new NumCombination(numbers);
+        return new NumCombination(numbers, expectedSize, min, max);
     }
 
     @Override

--- a/src/main/java/com/mastermind/services/GameFactory.java
+++ b/src/main/java/com/mastermind/services/GameFactory.java
@@ -1,20 +1,47 @@
 package com.mastermind.services;
 
+import com.mastermind.models.Difficulty;
 import com.mastermind.models.Game;
 import com.mastermind.models.NumCombination;
 import com.mastermind.models.Player;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Factory for creating Game instances with random number generation.
- * Handles the complexity of answer generation via external API.
+ * Factory for creating Game instances with configurable difficulty levels.
+ * 
+ * <p>This factory abstracts the complexity of generating secret combinations
+ * using external random number services with appropriate retry logic and fallbacks.
+ * Each game is created with a difficulty-appropriate secret combination.
  */
 @RequiredArgsConstructor
 public class GameFactory {
     private final NumberGenerator numberGenerator;
 
     public Game createGame(Player player) {
-        NumCombination answer = numberGenerator.generateNumbers();
-        return new Game(player, answer);
+       return createGame(player, Difficulty.NORMAL);
+    }
+
+    /**
+     * Creates a new game with the specified difficulty level.
+     * 
+     * <p>The secret combination is generated according to the difficulty constraints:
+     * <ul>
+     *   <li>EASY (3 digits, 0-5)</li>
+     *   <li>NORMAL (4 digits, 0-7)</li>
+     *   <li>HARD (5 digits, 0-9).</li>
+     * <ul/>
+     *
+     * @param player the player who will participate in the game
+     * @param difficulty the difficulty level that determines game constraints
+     * @return a new Game instance configured for the specified difficulty
+     */
+    public Game createGame(Player player, Difficulty difficulty) {
+        NumCombination answer =
+                numberGenerator.generateNumbers(difficulty.getCombinationSize(), difficulty.getMaxRange());
+
+        Game newGame = new Game(player, answer);
+        newGame.setDifficulty(difficulty);
+
+        return newGame;
     }
 }

--- a/src/main/java/com/mastermind/services/NumberGenerator.java
+++ b/src/main/java/com/mastermind/services/NumberGenerator.java
@@ -14,4 +14,13 @@ public interface NumberGenerator {
      * @return A valid NumCombination suitable for the game
      */
     NumCombination generateNumbers();
+
+    /**
+     * Generates a NumCombination with specified size and range constraints.
+     * 
+     * @param size the number of digits to generate
+     * @param maxRange the maximum value (inclusive) for each digit
+     * @return a valid NumCombination with the specified constraints
+     */
+    NumCombination generateNumbers(int size, int maxRange);
 }

--- a/src/main/java/com/mastermind/services/RandomNumberApiClient.java
+++ b/src/main/java/com/mastermind/services/RandomNumberApiClient.java
@@ -1,5 +1,6 @@
 package com.mastermind.services;
 
+import com.mastermind.config.GameConfig;
 import com.mastermind.models.NumCombination;
 
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class RandomNumberApiClient {
-    private static final String INTEGER_GEN_URI = "https://www.random.org/integers/?num=4&min=0&max=7&col=1&base=10&format=plain&rnd=new";
+    private static final String INTEGER_GEN_URI = "https://www.random.org/integers/?num=%d&min=0&max=%d&col=1&base=10&format=plain&rnd=new";
 
     private final HttpClient client;
 
@@ -26,15 +27,21 @@ public class RandomNumberApiClient {
     }
 
     public NumCombination getRandomNums() throws RandomNumberApiException {
+        return getRandomNums(GameConfig.DEFAULT_ANSWER_SIZE, GameConfig.DEFAULT_MAX_VALUE);
+    }
+
+    public NumCombination getRandomNums(int size, int max) throws RandomNumberApiException {
+        String formattedString = INTEGER_GEN_URI.formatted(size, max);
+
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(INTEGER_GEN_URI))
+                .uri(URI.create(formattedString))
                 .GET()
                 .timeout(Duration.ofSeconds(10))
                 .build();
 
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            
+
             // Check HTTP status code first
             if (response.statusCode() == 200) {
                 // Success - parse the numbers
@@ -51,7 +58,7 @@ public class RandomNumberApiClient {
             throw new RandomNumberApiException("Network error while contacting Random.org API", e);
         }
     }
-    
+
     private NumCombination parseSuccessResponse(String responseBody) {
         // Split body on every new line (Ref: https://www.random.org/clients/http/api/)
         String[] lines = responseBody

--- a/src/main/java/com/mastermind/services/RandomNumberApiClient.java
+++ b/src/main/java/com/mastermind/services/RandomNumberApiClient.java
@@ -44,8 +44,8 @@ public class RandomNumberApiClient {
 
             // Check HTTP status code first
             if (response.statusCode() == 200) {
-                // Success - parse the numbers
-                return parseSuccessResponse(response.body());
+                // Success - parse the numbers with constraints
+                return parseSuccessResponse(response.body(), size, max);
             } else if (response.statusCode() == 503) {
                 // Service unavailable - handle error response
                 throw new RandomNumberApiException("Random.org API error: " + extractErrorMessage(response.body()));
@@ -59,7 +59,7 @@ public class RandomNumberApiClient {
         }
     }
 
-    private NumCombination parseSuccessResponse(String responseBody) {
+    private NumCombination parseSuccessResponse(String responseBody, int size, int max) {
         // Split body on every new line (Ref: https://www.random.org/clients/http/api/)
         String[] lines = responseBody
                 .trim()
@@ -70,7 +70,7 @@ public class RandomNumberApiClient {
                 .map(Integer::parseInt)
                 .toList();
 
-        return new NumCombination(integerList);
+        return new NumCombination(integerList, size, 0, max);
     }
     
     private String extractErrorMessage(String responseBody) {

--- a/src/main/java/com/mastermind/services/RandomNumberGenerator.java
+++ b/src/main/java/com/mastermind/services/RandomNumberGenerator.java
@@ -1,5 +1,6 @@
 package com.mastermind.services;
 
+import com.mastermind.config.GameConfig;
 import com.mastermind.models.NumCombination;
 
 import java.util.ArrayList;
@@ -19,47 +20,50 @@ public class RandomNumberGenerator implements NumberGenerator {
     
     @Override
     public NumCombination generateNumbers() {
+       return generateNumbers(GameConfig.DEFAULT_ANSWER_SIZE, GameConfig.DEFAULT_MAX_VALUE);
+    }
+
+    @Override
+    public NumCombination generateNumbers(int combinationSize, int maxRange) {
         int maxAttempts = 3; // Original + 2 retries
         int delayMs = 1000; // 1-second base delay
-        
+
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
-                return apiClient.getRandomNums();
+                return apiClient.getRandomNums(combinationSize, maxRange);
             } catch (RandomNumberApiException e) {
                 if (attempt == maxAttempts) {
                     // All attempts failed, fall back to local random
                     System.out.println("API failed after " + maxAttempts + " attempts, using local random generation");
-                    return generateLocalRandomNumbers();
+                    return generateLocalRandomNumbers(combinationSize, maxRange);
                 }
-                
+
                 // Wait before retry with exponential backoff
                 try {
                     Thread.sleep(delayMs * attempt); // 1s, 2s delays
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     // If interrupted, fall back immediately
-                    return generateLocalRandomNumbers();
+                    return generateLocalRandomNumbers(combinationSize, maxRange);
                 }
-                
+
                 System.out.println("API attempt " + attempt + " failed, retrying...");
             }
         }
-        
+
         // This should never be reached, but fallback just in case
-        return generateLocalRandomNumbers();
+        return generateLocalRandomNumbers(combinationSize, maxRange);
     }
     
-    private NumCombination generateLocalRandomNumbers() {
-        final int size = 4;
-        final int maxValue = 8; // Exclusive upper bound for Random.nextInt()
+    private NumCombination generateLocalRandomNumbers(int size, int maxValue) {
         
         Random random = new Random();
         List<Integer> numbers = new ArrayList<>();
         
         for (int i = 0; i < size; i++) {
-            numbers.add(random.nextInt(maxValue)); // 0-7 range
+            numbers.add(random.nextInt(maxValue + 1));
         }
         
-        return new NumCombination(numbers);
+        return new NumCombination(numbers, size, 0, maxValue);
     }
 }

--- a/src/main/java/com/mastermind/ui/UserInterface.java
+++ b/src/main/java/com/mastermind/ui/UserInterface.java
@@ -71,8 +71,7 @@ public class UserInterface {
                     2. Normal: 4 digits, numbers 0-7
                     3. Hard: 5 digits, numbers 0-9
                     
-                    Enter your choice (1-3):\s
-                    """);
+                    Enter your choice (1-3):\s """);
 
             try {
                 return Integer.parseInt(SCANNER.nextLine().trim());

--- a/src/main/java/com/mastermind/ui/UserInterface.java
+++ b/src/main/java/com/mastermind/ui/UserInterface.java
@@ -6,6 +6,7 @@ import com.mastermind.models.NumCombination;
 import com.mastermind.models.Status;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Scanner;
 
 /**
@@ -182,7 +183,9 @@ public class UserInterface {
         System.out.println("Error: " + message);
     }
 
-    public void displayHint(String numFromAnswer) {
-        System.out.println("The combination contains a number " + numFromAnswer);
+    public void displayHint(Optional<String> numFromAnswer) {
+        numFromAnswer.ifPresentOrElse(
+                s -> System.out.println("The combination contains a number " + s),
+                () -> System.out.println("No more hints left"));
     }
 }

--- a/src/main/java/com/mastermind/ui/UserInterface.java
+++ b/src/main/java/com/mastermind/ui/UserInterface.java
@@ -15,22 +15,22 @@ public class UserInterface {
     private static final Scanner SCANNER = new Scanner(System.in);
 
     // -- Input --
-    public NumCombination promptForGuess(int remainingAttempts) {
+    public NumCombination promptForGuess(int remainingAttempts, int expectedSize, int minValue, int maxValue) {
         while (true) {
             System.out.printf("Enter your guess (%d attempts remaining): ", remainingAttempts);
             String input = SCANNER.nextLine().trim();
 
             try {
-                return NumCombination.parse(input);
+                return NumCombination.parse(input, expectedSize, minValue, maxValue);
             } catch (IllegalArgumentException e) {
                 System.out.printf("""
                     
                     *** INVALID INPUT ***
                     %s
                     
-                    => Please enter 4 numbers between 0-7, separated by spaces (e.g., '1 2 3 4')
+                    => Please enter %d numbers between %d-%d, separated by spaces
                     
-                    """, e.getMessage());
+                    """, e.getMessage(), expectedSize, minValue, maxValue);
             }
         }
     }
@@ -67,9 +67,9 @@ public class UserInterface {
                     -----------------------------
                     Pick Difficulty Level
                     -----------------------------
-                    1. Easy:
-                    2. Normal:
-                    3. Hard
+                    1. Easy: 3 digits, numbers 0-5
+                    2. Normal: 4 digits, numbers 0-7
+                    3. Hard: 5 digits, numbers 0-9
                     
                     Enter your choice (1-3):\s
                     """);
@@ -87,8 +87,8 @@ public class UserInterface {
     public void displayWelcomeMessage() {
         System.out.print("""
             ***** Welcome to Mastermind-CLI *****
-            - Guess the secret 4-number combination!
-            - Numbers range from 0-7, duplicates allowed.
+            - Guess the secret number combination!
+            - Choose your difficulty level to determine game constraints.
             - You have 10 attempts to crack the code.
             
             """);

--- a/src/main/java/com/mastermind/ui/UserInterface.java
+++ b/src/main/java/com/mastermind/ui/UserInterface.java
@@ -61,6 +61,27 @@ public class UserInterface {
         return name;
     }
 
+    public int promptForDifficultyLevel() {
+        while (true) {
+            System.out.print("""
+                    -----------------------------
+                    Pick Difficulty Level
+                    -----------------------------
+                    1. Easy:
+                    2. Normal:
+                    3. Hard
+                    
+                    Enter your choice (1-3):\s
+                    """);
+
+            try {
+                return Integer.parseInt(SCANNER.nextLine().trim());
+            } catch (NumberFormatException e) {
+                System.out.println("\n*** Invalid input. Please enter a number. ***\n");
+            }
+        }
+    }
+
 
     // -- Display --
     public void displayWelcomeMessage() {

--- a/src/test/java/com/mastermind/MainTest.java
+++ b/src/test/java/com/mastermind/MainTest.java
@@ -21,7 +21,7 @@ class MainTest {
     @Test
     void mainShouldRunWithoutException() {
         // Arrange - Provide input to exit game immediately
-        System.setIn(new ByteArrayInputStream("TestPlayer\n3\nn\n".getBytes())); // Player name, exit game, no to play again
+        System.setIn(new ByteArrayInputStream("2\nTestPlayer\n3\nn\n".getBytes())); // Normal difficulty, player name, exit game, no to play again
 
         // Act & Assert - Should not throw any exceptions during dependency wiring and startup
         assertDoesNotThrow(() -> Main.main(new String[]{}));

--- a/src/test/java/com/mastermind/controller/GameControllerTest.java
+++ b/src/test/java/com/mastermind/controller/GameControllerTest.java
@@ -76,7 +76,8 @@ class GameControllerTest {
         void shouldDisplayWelcomeMessageAndCreateGameOnStartup() {
             // Arrange
             when(mockUI.promptForPlayerName()).thenReturn("TestPlayer");
-            when(mockGameFactory.createGame(any(Player.class))).thenReturn(mockGame);
+            when(mockUI.promptForDifficultyLevel()).thenReturn(2); // NORMAL difficulty
+            when(mockGameFactory.createGame(any(Player.class), any())).thenReturn(mockGame);
             when(mockGame.getStatus()).thenReturn(Status.IN_PROGRESS);
             when(mockGame.getPlayer()).thenReturn(new Player("TestPlayer"));
             when(mockUI.displayGameMenu(anyString(), anyInt(), anyInt())).thenReturn(3); // Exit immediately
@@ -88,7 +89,7 @@ class GameControllerTest {
             // Assert
             verify(mockUI, times(1)).displayWelcomeMessage();
             verify(mockUI, times(1)).promptForPlayerName();
-            verify(mockGameFactory, times(1)).createGame(any(Player.class));
+            verify(mockGameFactory, times(1)).createGame(any(Player.class), any());
             verify(mockGame, times(1)).start();
         }
 
@@ -97,8 +98,9 @@ class GameControllerTest {
         void shouldHandleGameCreationFailureGracefully() {
             // Arrange
             when(mockUI.promptForPlayerName()).thenReturn("TestPlayer");
+            when(mockUI.promptForDifficultyLevel()).thenReturn(2); // NORMAL difficulty
             RuntimeException gameCreationError = new RuntimeException("API failure");
-            when(mockGameFactory.createGame(any(Player.class))).thenThrow(gameCreationError);
+            when(mockGameFactory.createGame(any(Player.class), any())).thenThrow(gameCreationError);
             when(mockUI.promptForNewGame()).thenReturn(false);
 
             // Act
@@ -248,10 +250,12 @@ class GameControllerTest {
                 .thenReturn("Player1")
                 .thenReturn("Player2");
             
+            when(mockUI.promptForDifficultyLevel()).thenReturn(2); // NORMAL difficulty for both games
+            
             when(firstGame.getPlayer()).thenReturn(new Player("Player1"));
             when(secondGame.getPlayer()).thenReturn(new Player("Player2"));
             
-            when(mockGameFactory.createGame(any(Player.class)))
+            when(mockGameFactory.createGame(any(Player.class), any()))
                 .thenReturn(firstGame)
                 .thenReturn(secondGame);
             
@@ -270,7 +274,7 @@ class GameControllerTest {
 
             // Assert
             verify(mockUI, times(1)).displayWelcomeMessage(); // Only once at startup
-            verify(mockGameFactory, times(2)).createGame(any(Player.class)); // Two games created
+            verify(mockGameFactory, times(2)).createGame(any(Player.class), any()); // Two games created
             verify(firstGame, times(1)).start();
             verify(secondGame, times(1)).start();
             verify(mockUI, times(2)).promptForNewGame(); // Asked twice
@@ -281,7 +285,8 @@ class GameControllerTest {
         void shouldStopWhenUserDeclinesToPlayAgain() {
             // Arrange
             when(mockUI.promptForPlayerName()).thenReturn("TestPlayer");
-            when(mockGameFactory.createGame(any(Player.class))).thenReturn(mockGame);
+            when(mockUI.promptForDifficultyLevel()).thenReturn(2); // NORMAL difficulty
+            when(mockGameFactory.createGame(any(Player.class), any())).thenReturn(mockGame);
             when(mockGame.getStatus()).thenReturn(Status.WON);
             when(mockGame.getAnswer()).thenReturn(new NumCombination(Arrays.asList(1, 2, 3, 4)));
             when(mockGame.getPlayer()).thenReturn(new Player("TestPlayer"));
@@ -292,7 +297,7 @@ class GameControllerTest {
 
             // Assert
             verify(mockUI, times(1)).promptForNewGame();
-            verify(mockGameFactory, times(1)).createGame(any(Player.class)); // Only one game
+            verify(mockGameFactory, times(1)).createGame(any(Player.class), any()); // Only one game
         }
     }
 }

--- a/src/test/java/com/mastermind/controller/GameControllerTest.java
+++ b/src/test/java/com/mastermind/controller/GameControllerTest.java
@@ -1,5 +1,6 @@
 package com.mastermind.controller;
 
+import com.mastermind.models.Difficulty;
 import com.mastermind.models.Feedback;
 import com.mastermind.models.Game;
 import com.mastermind.models.NumCombination;
@@ -117,8 +118,10 @@ class GameControllerTest {
         @BeforeEach
         void setUpGameMocks() {
             when(mockUI.promptForPlayerName()).thenReturn("TestPlayer");
-            when(mockGameFactory.createGame(any(Player.class))).thenReturn(mockGame);
+            when(mockUI.promptForDifficultyLevel()).thenReturn(2); // NORMAL difficulty
+            when(mockGameFactory.createGame(any(Player.class), any())).thenReturn(mockGame);
             when(mockGame.getPlayer()).thenReturn(new Player("TestPlayer"));
+            when(mockGame.getDifficulty()).thenReturn(Difficulty.NORMAL);
             when(mockUI.promptForNewGame()).thenReturn(false);
         }
 
@@ -136,7 +139,7 @@ class GameControllerTest {
             when(mockGame.getRemainingAttempts()).thenReturn(9);
             when(mockGame.getAnswer()).thenReturn(testAnswer);
             when(mockUI.displayGameMenu(eq("TestPlayer"), eq(9), anyInt())).thenReturn(1); // MAKE_GUESS choice
-            when(mockUI.promptForGuess(9)).thenReturn(testGuess);
+            when(mockUI.promptForGuess(9, 4, 0, 7)).thenReturn(testGuess);
             when(mockGame.playerGuess(testGuess)).thenReturn(testFeedback);
 
             // Act
@@ -144,7 +147,7 @@ class GameControllerTest {
 
             // Assert
             verify(mockUI, times(1)).displayGameMenu(eq("TestPlayer"), eq(9), anyInt());
-            verify(mockUI, times(1)).promptForGuess(9);
+            verify(mockUI, times(1)).promptForGuess(9, 4, 0, 7);
             verify(mockGame, times(1)).playerGuess(testGuess);
             verify(mockUI, times(1)).displayFeedback(testGuess, testFeedback);
             verify(mockUI, times(1)).displayGameResults(Status.WON, testAnswer, "TestPlayer"); // Called once in handleGuess when game ends

--- a/src/test/java/com/mastermind/controller/GameControllerTest.java
+++ b/src/test/java/com/mastermind/controller/GameControllerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -222,7 +223,7 @@ class GameControllerTest {
                 .thenReturn(Status.LOST);        // Second check - end game
             when(mockGame.getRemainingAttempts()).thenReturn(6);
             when(mockGame.getAnswer()).thenReturn(new NumCombination(Arrays.asList(1, 2, 3, 4)));
-            when(mockGame.getHint()).thenReturn("3");
+            when(mockGame.getHint()).thenReturn(Optional.of("3"));
             when(mockUI.displayGameMenu(eq("TestPlayer"), eq(6), anyInt())).thenReturn(4); // GET_HINT choice
 
             // Act
@@ -231,7 +232,7 @@ class GameControllerTest {
             // Assert
             verify(mockUI, times(1)).displayGameMenu(eq("TestPlayer"), eq(6), anyInt());
             verify(mockGame, times(1)).getHint();
-            verify(mockUI, times(1)).displayHint("3");
+            verify(mockUI, times(1)).displayHint(Optional.of("3"));
         }
     }
 

--- a/src/test/java/com/mastermind/models/GameTest.java
+++ b/src/test/java/com/mastermind/models/GameTest.java
@@ -134,7 +134,7 @@ class GameTest {
             Game game = new Game(testPlayer, testAnswer);
 
             // Act & Assert
-            assertThrows(IllegalArgumentException.class, () -> game.playerGuess(testGuess));
+            assertThrows(IllegalStateException.class, () -> game.playerGuess(testGuess));
         }
 
         @Test
@@ -146,7 +146,7 @@ class GameTest {
             game.playerGuess(testAnswer); // Win the game
 
             // Act & Assert
-            assertThrows(IllegalArgumentException.class, () -> game.playerGuess(testGuess));
+            assertThrows(IllegalStateException.class, () -> game.playerGuess(testGuess));
         }
 
         @Test
@@ -163,7 +163,7 @@ class GameTest {
             }
 
             // Act & Assert
-            assertThrows(IllegalArgumentException.class, () -> game.playerGuess(testGuess));
+            assertThrows(IllegalStateException.class, () -> game.playerGuess(testGuess));
         }
 
         @Test

--- a/src/test/java/com/mastermind/services/GameFactoryTest.java
+++ b/src/test/java/com/mastermind/services/GameFactoryTest.java
@@ -62,7 +62,7 @@ class GameFactoryTest {
             // Arrange
             Player testPlayer = new Player("TestPlayer");
             NumCombination expectedAnswer = new NumCombination(Arrays.asList(1, 2, 3, 4));
-            when(mockNumberGenerator.generateNumbers()).thenReturn(expectedAnswer);
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt())).thenReturn(expectedAnswer);
 
             // Act
             Game result = gameFactory.createGame(testPlayer);
@@ -83,13 +83,13 @@ class GameFactoryTest {
             // Arrange
             Player testPlayer = new Player("TestPlayer");
             NumCombination mockAnswer = new NumCombination(Arrays.asList(0, 1, 2, 3));
-            when(mockNumberGenerator.generateNumbers()).thenReturn(mockAnswer);
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt())).thenReturn(mockAnswer);
 
             // Act
             gameFactory.createGame(testPlayer);
 
             // Assert
-            verify(mockNumberGenerator, times(1)).generateNumbers();
+            verify(mockNumberGenerator, times(1)).generateNumbers(anyInt(), anyInt());
         }
 
         @Test
@@ -102,7 +102,7 @@ class GameFactoryTest {
             NumCombination answer1 = new NumCombination(Arrays.asList(1, 2, 3, 4));
             NumCombination answer2 = new NumCombination(Arrays.asList(5, 6, 7, 0));
             
-            when(mockNumberGenerator.generateNumbers())
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt()))
                 .thenReturn(answer1)
                 .thenReturn(answer2);
 
@@ -117,7 +117,7 @@ class GameFactoryTest {
             assertEquals(player2, game2.getPlayer());
             assertEquals(answer2, game2.getAnswer());
             
-            verify(mockNumberGenerator, times(2)).generateNumbers();
+            verify(mockNumberGenerator, times(2)).generateNumbers(anyInt(), anyInt());
         }
 
     }
@@ -132,7 +132,7 @@ class GameFactoryTest {
             // Arrange
             Player testPlayer = new Player("TestPlayer");
             NumCombination mockAnswer = new NumCombination(Arrays.asList(1, 2, 3, 4));
-            when(mockNumberGenerator.generateNumbers()).thenReturn(mockAnswer);
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt())).thenReturn(mockAnswer);
 
             // Act
             Game result = gameFactory.createGame(testPlayer);
@@ -147,7 +147,7 @@ class GameFactoryTest {
             // Arrange
             Player testPlayer = new Player("TestPlayer");
             NumCombination mockAnswer = new NumCombination(Arrays.asList(1, 2, 3, 4));
-            when(mockNumberGenerator.generateNumbers()).thenReturn(mockAnswer);
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt())).thenReturn(mockAnswer);
 
             // Act
             Game result = gameFactory.createGame(testPlayer);
@@ -162,7 +162,7 @@ class GameFactoryTest {
             // Arrange
             Player testPlayer = new Player("TestPlayer");
             NumCombination mockAnswer = new NumCombination(Arrays.asList(1, 2, 3, 4));
-            when(mockNumberGenerator.generateNumbers()).thenReturn(mockAnswer);
+            when(mockNumberGenerator.generateNumbers(anyInt(), anyInt())).thenReturn(mockAnswer);
 
             // Act
             Game result = gameFactory.createGame(testPlayer);

--- a/src/test/java/com/mastermind/services/RandomNumberGeneratorTest.java
+++ b/src/test/java/com/mastermind/services/RandomNumberGeneratorTest.java
@@ -59,7 +59,7 @@ class RandomNumberGeneratorTest {
         void shouldReturnApiResultOnFirstAttemptSuccess() {
             // Arrange
             NumCombination expectedAnswer = new NumCombination(Arrays.asList(1, 2, 3, 4));
-            when(mockApiClient.getRandomNums()).thenReturn(expectedAnswer);
+            when(mockApiClient.getRandomNums(anyInt(), anyInt())).thenReturn(expectedAnswer);
 
             // Act
             NumCombination result = generator.generateNumbers();
@@ -67,7 +67,7 @@ class RandomNumberGeneratorTest {
             // Assert
             assertNotNull(result);
             assertEquals(expectedAnswer, result);
-            verify(mockApiClient, times(1)).getRandomNums();
+            verify(mockApiClient, times(1)).getRandomNums(anyInt(), anyInt());
         }
 
         @Test
@@ -75,7 +75,7 @@ class RandomNumberGeneratorTest {
         void shouldReturnApiResultWithDifferentNumberCombinations() {
             // Arrange
             NumCombination expectedAnswer = new NumCombination(Arrays.asList(7, 0, 5, 2));
-            when(mockApiClient.getRandomNums()).thenReturn(expectedAnswer);
+            when(mockApiClient.getRandomNums(anyInt(), anyInt())).thenReturn(expectedAnswer);
 
             // Act
             NumCombination result = generator.generateNumbers();
@@ -96,7 +96,7 @@ class RandomNumberGeneratorTest {
         void shouldSucceedOnFirstRetryAttempt() {
             // Arrange
             NumCombination expectedAnswer = new NumCombination(Arrays.asList(3, 4, 5, 6));
-            when(mockApiClient.getRandomNums())
+            when(mockApiClient.getRandomNums(anyInt(), anyInt()))
                     .thenThrow(new RandomNumberApiException("First attempt fails"))
                     .thenReturn(expectedAnswer); // Second attempt succeeds
 
@@ -106,7 +106,7 @@ class RandomNumberGeneratorTest {
             // Assert
             assertNotNull(result);
             assertEquals(expectedAnswer, result);
-            verify(mockApiClient, times(2)).getRandomNums();
+            verify(mockApiClient, times(2)).getRandomNums(anyInt(), anyInt());
         }
 
         @Test
@@ -114,7 +114,7 @@ class RandomNumberGeneratorTest {
         void shouldSucceedOnSecondRetryAttempt() {
             // Arrange
             NumCombination expectedAnswer = new NumCombination(Arrays.asList(0, 1, 7, 6));
-            when(mockApiClient.getRandomNums())
+            when(mockApiClient.getRandomNums(anyInt(), anyInt()))
                     .thenThrow(new RandomNumberApiException("First attempt fails"))
                     .thenThrow(new RandomNumberApiException("Second attempt fails"))
                     .thenReturn(expectedAnswer); // Third attempt succeeds
@@ -125,7 +125,7 @@ class RandomNumberGeneratorTest {
             // Assert
             assertNotNull(result);
             assertEquals(expectedAnswer, result);
-            verify(mockApiClient, times(3)).getRandomNums();
+            verify(mockApiClient, times(3)).getRandomNums(anyInt(), anyInt());
         }
     }
 
@@ -137,7 +137,7 @@ class RandomNumberGeneratorTest {
         @DisplayName("should fall back to local generation when all API attempts fail")
         void shouldFallBackToLocalGenerationWhenAllApiAttemptsFail() {
             // Arrange
-            when(mockApiClient.getRandomNums()).thenThrow(new RandomNumberApiException("API always fails"));
+            when(mockApiClient.getRandomNums(anyInt(), anyInt())).thenThrow(new RandomNumberApiException("API always fails"));
 
             // Act
             NumCombination result = generator.generateNumbers();
@@ -154,14 +154,14 @@ class RandomNumberGeneratorTest {
             }
             
             // Verify all retry attempts were made
-            verify(mockApiClient, times(3)).getRandomNums();
+            verify(mockApiClient, times(3)).getRandomNums(anyInt(), anyInt());
         }
 
         @Test
         @DisplayName("should generate different fallback numbers on multiple calls")
         void shouldGenerateDifferentFallbackNumbersOnMultipleCalls() {
             // Arrange
-            when(mockApiClient.getRandomNums()).thenThrow(new RandomNumberApiException("API always fails"));
+            when(mockApiClient.getRandomNums(anyInt(), anyInt())).thenThrow(new RandomNumberApiException("API always fails"));
 
             // Act - Generate multiple sets
             NumCombination result1 = generator.generateNumbers();
@@ -183,14 +183,14 @@ class RandomNumberGeneratorTest {
             assertFalse(allSame, "Generated numbers should have some variation");
             
             // Verify API was called 3 times for each generation (3 generations × 3 attempts each)
-            verify(mockApiClient, times(9)).getRandomNums();
+            verify(mockApiClient, times(9)).getRandomNums(anyInt(), anyInt());
         }
 
         @Test
         @DisplayName("should handle thread interruption during retry")
         void shouldHandleThreadInterruptionDuringRetry() {
             // Arrange
-            when(mockApiClient.getRandomNums()).thenThrow(new RandomNumberApiException("API fails"));
+            when(mockApiClient.getRandomNums(anyInt(), anyInt())).thenThrow(new RandomNumberApiException("API fails"));
             
             // Interrupt the current thread to simulate interruption during sleep
             Thread.currentThread().interrupt();
@@ -209,7 +209,7 @@ class RandomNumberGeneratorTest {
             }
             
             // Should have tried at least once before interruption caused fallback
-            verify(mockApiClient, atLeast(1)).getRandomNums();
+            verify(mockApiClient, atLeast(1)).getRandomNums(anyInt(), anyInt());
             
             // Clean up the interrupted status
             assertTrue(Thread.interrupted(), "Thread should have been interrupted");


### PR DESCRIPTION
  ## Summary
  This PR introduces difficulty levels to the classic Mastermind game mode, allowing players to choose between:
  - Easy: 3 digits between 0-5
  - Normal: 4 digits between 0-7 (default implementation)
  - Hard: 5 digits between 0-9

  ## Why These Changes
  To cater to players of varying experience levels and time  😂.

  ## Testing Done
  - Manual CLI testing across all difficulty levels
  - [x] Passes all tests `./gradlew test`

  ## Additional Notes
  - For this feature, I purposely chose to use method overloading instead of replacing existing methods and focused on making the system easily extendable for future
  difficulty additions.